### PR TITLE
Remove out dated info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,2 @@
 # mirrulations-website
 A exploratory repo for the website team
-
-## Current Team
-- Brandon Yang
-- Saul Sanchez
-- Seth Coleman
-
-## First Weekend Plans: 
-Create hello world in AWS Amplify
-
-## What we will need from other teams:
-(We plan to communicate more officially about this on Sunday)
-- Search Team: How will the search results be formatted? So we can design the search page
-- API Team: 
-    - Discuss what end points we need, currently thinking about one for searching and one for filtering the search
-    - Should we do Server Side Rendering?


### PR DESCRIPTION
I put some information in the readme over the weekend that either was only relevant to that weekend or recorded elsewhere. This pull request removes that information.