### PR TITLE
Tweaks to results page

### DIFF
--- a/javascript/components/results.jsx
+++ b/javascript/components/results.jsx
@@ -42,6 +42,7 @@ const ResultsSection = ({ results, onPageChange }) => {
               <p><strong>Summary:</strong> {docket.summary ? (docket.summary.length > 300 ? `${docket.summary.substring(0, 300)}...` : docket.summary) : "No summary available"}</p>
               {/* Use the new TimelineModal component instead of displaying dates directly */}
               <TimelineModal key={docket.id} timelineDates={docket.timelineDates}/>
+              <p><strong>Open for comments?:</strong> {docket.timelineDates.dateClosed === null ? "Yes" : "No"}</p>
             </div>
             
             <div className="d-flex align-items-end">

--- a/javascript/components/results.jsx
+++ b/javascript/components/results.jsx
@@ -42,12 +42,7 @@ const ResultsSection = ({ results, onPageChange }) => {
               <p><strong>Summary:</strong> {docket.summary ? (docket.summary.length > 300 ? `${docket.summary.substring(0, 300)}...` : docket.summary) : "No summary available"}</p>
               {/* Use the new TimelineModal component instead of displaying dates directly */}
               <TimelineModal key={docket.id} timelineDates={docket.timelineDates}/>
-              <p>
-                <strong>Open for comments?:</strong>{" "}
-                {docket.timelineDates.dateCommentsOpened !== null && docket.timelineDates.dateClosed === null
-                  ? "Yes"
-                  : "No"}
-              </p>
+              <p><strong>Open for comments?:</strong> {docket.isOpenForComment === true ? "Yes" : "No"}</p>
             </div>
             
             <div className="d-flex align-items-end">

--- a/javascript/components/results.jsx
+++ b/javascript/components/results.jsx
@@ -42,7 +42,12 @@ const ResultsSection = ({ results, onPageChange }) => {
               <p><strong>Summary:</strong> {docket.summary ? (docket.summary.length > 300 ? `${docket.summary.substring(0, 300)}...` : docket.summary) : "No summary available"}</p>
               {/* Use the new TimelineModal component instead of displaying dates directly */}
               <TimelineModal key={docket.id} timelineDates={docket.timelineDates}/>
-              <p><strong>Open for comments?:</strong> {docket.timelineDates.dateClosed === null ? "Yes" : "No"}</p>
+              <p>
+                <strong>Open for comments?:</strong>{" "}
+                {docket.timelineDates.dateCommentsOpened !== null && docket.timelineDates.dateClosed === null
+                  ? "Yes"
+                  : "No"}
+              </p>
             </div>
             
             <div className="d-flex align-items-end">

--- a/javascript/components/timelineModal.jsx
+++ b/javascript/components/timelineModal.jsx
@@ -48,7 +48,7 @@ function TimelineModal({ timelineDates }) {
               {generate_date_html("Date Modified", checkedTimelineDates.dateModified, "black")}
               {generate_date_html("Date Created", checkedTimelineDates.dateCreated, "purple")}
               {generate_date_html("Date Effective", checkedTimelineDates.dateEffective, "blue")}
-              {generate_date_html("Date Closed", checkedTimelineDates.dateClosed, "red")}
+              {generate_date_html("Date Comment Closed", checkedTimelineDates.dateClosed, "red")}
               {generate_date_html("Date Comments Opened", checkedTimelineDates.dateCommentsOpened, "green")}
             </tbody>
           </table>


### PR DESCRIPTION
This tweak adds the "open for comments" data to the results page, displaying yes if docket.timelineDates.dateClosed is null and no if there is some date.  It also adds a change requested by Brandon, changing "Date Closed" to "Date Comments Closed" for further clarity